### PR TITLE
Update base image, serve file simply to be able to see result

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,10 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-node:latest
+FROM balenalib/%%BALENA_MACHINE_NAME%%-node:12-buster-run
+
+# We need to downgrade the relevant binaries for balenaOS
+# versions up to 2.38.0, because of firmware changes
+RUN    apt-get update \
+    && apt-get install libraspberrypi-bin=1.20180328-1~nokernel1 libraspberrypi0=1.20180328-1~nokernel1 --allow-downgrades -y \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
 

--- a/app.js
+++ b/app.js
@@ -1,8 +1,23 @@
-var RaspiCam = require("raspicam");
+const RaspiCam = require("raspicam");
+const handler = require('serve-handler');
+const http = require('http');
 
-var camera = new RaspiCam({
+// Set up file server
+const server = http.createServer((request, response) => {
+	return handler(request, response, {
+		'public': '/data',
+		'renderSingle': 'true'
+	});
+  })
+
+server.listen(80, () => {
+   console.log('Server running on port 80');
+});
+
+// Camera related functions
+const camera = new RaspiCam({
 	mode: "photo",
-	output: "../data/image.jpg",
+	output: "/data/image.jpg",
 	encoding: "jpg",
 	timeout: 100 
 });
@@ -11,7 +26,6 @@ camera.on("started", function( err, timestamp ){
 	console.log("photo started at " + timestamp );
 });
 
-
 camera.on("read", function( err, timestamp, filename ){
 	console.log("photo image captured with filename: " + filename );
 	//we can now do stuff with the captured image, which is stored in /data
@@ -19,6 +33,9 @@ camera.on("read", function( err, timestamp, filename ){
 
 camera.on("exit", function( timestamp ){
 	console.log("photo child process has exited at " + timestamp );
+	console.log("Connect to the 'main' service and visit the /data folder to find the captured image");
+	console.log("or connect to the device on port 80 locally / connect over the Public Device URL");
+	console.log("To snap another picture, restart the service");
 });
 
 camera.start();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "main": "app.js",
   "dependencies": {
-    "raspicam": "~0.2.14"
+    "raspicam": "~0.2.14",
+    "serve": "^11.1.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Update base image to balenalib, as that's the future (present).

Using the 'serve' package https://www.npmjs.com/package/serve to quickly show the single image shot, over the network or public URL. This is done, as otherwise the project doesn't work as described in the readme - it will loop as the camera exits, and one can never really get into theck `/data`. With the file server it will stay on and people can see the image itself, unlike just seeing there's a file, when connecting over the web terminal. Thus the promise of the readme should be better fulfilled.

Also add current workaround for the issue in #3, downgrading the packages that are required for `raspistill`. When all our Pi images have updated firmware, we'll be able to remove it (and should remove it at that time).

Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>